### PR TITLE
Fix pruning mask in function `invert`

### DIFF
--- a/05-pruning/Unification.hs
+++ b/05-pruning/Unification.hs
@@ -37,7 +37,7 @@ invert :: Lvl -> Spine -> IO (PartialRenaming, Maybe Pruning)
 invert gamma sp = do
   let go :: Spine -> IO (Lvl, IS.IntSet, IM.IntMap Lvl, IS.IntSet, Spine)
       go []                                        = pure (0, mempty, mempty, mempty, [])
-      go (sp :> (force -> ft @ (VVar (Lvl x)), i)) = do 
+      go (sp :> (force -> ft@(VVar (Lvl x)), i)) = do 
         (dom, domvars, ren, nlvars, fsp) <- go sp
         case IS.member x domvars of
           True  -> pure (dom + 1, domvars,             IM.delete x ren,     IS.insert x nlvars, fsp :> (ft, i))

--- a/05-pruning/Unification.hs
+++ b/05-pruning/Unification.hs
@@ -35,20 +35,25 @@ skip (PRen occ dom cod ren) = PRen occ dom (cod + 1) ren
 --   Optionally returns a pruning of nonlinear spine entries, if there's any.
 invert :: Lvl -> Spine -> IO (PartialRenaming, Maybe Pruning)
 invert gamma sp = do
+  let go :: Spine -> IO (Lvl, IS.IntSet, IM.IntMap Lvl, IS.IntSet, Spine)
+      go []                                        = pure (0, mempty, mempty, mempty, [])
+      go (sp :> (force -> ft @ (VVar (Lvl x)), i)) = do 
+        (dom, domvars, ren, nlvars, fsp) <- go sp
+        case IS.member x domvars of
+          True  -> pure (dom + 1, domvars,             IM.delete x ren,     IS.insert x nlvars, fsp :> (ft, i))
+          False -> pure (dom + 1, IS.insert x domvars, IM.insert x dom ren, nlvars,             fsp :> (ft, i))
+      go _                                         = throwIO UnifyError
 
-  let go :: Spine -> IO (Lvl, IS.IntSet, IM.IntMap Lvl, Pruning, Bool)
-      go []             = pure (0, mempty, mempty, [], True)
-      go (sp :> (t, i)) = do
-        (dom, domvars, ren, pr, isLinear) <- go sp
-        case force t of
-          VVar (Lvl x) -> case IS.member x domvars of
-            True  -> pure (dom + 1, domvars,             IM.delete x ren,     Nothing : pr, False   )
-            False -> pure (dom + 1, IS.insert x domvars, IM.insert x dom ren, Just i  : pr, isLinear)
-          _ -> throwIO UnifyError
+  (dom, domvars, ren, nlvars, fsp) <- go sp
 
-  (dom, domvars, ren, pr, isLinear) <- go sp
-  pure (PRen Nothing dom gamma ren, pr <$ guard (not $ isLinear))
+  let mask :: Spine -> Pruning 
+      mask []                         = []
+      mask (fsp :> (VVar (Lvl x), i)) 
+        | IS.member x nlvars          = Nothing : mask fsp
+        | otherwise                   = Just i : mask fsp
+      mask _                          = impossible
 
+  pure (PRen Nothing dom gamma ren, mask fsp <$ guard (not $ IS.null nlvars))
 
 -- | Remove some arguments from a closed iterated Pi type.
 pruneTy :: RevPruning -> VTy -> IO Ty

--- a/05-pruning/Unification.hs
+++ b/05-pruning/Unification.hs
@@ -35,23 +35,22 @@ skip (PRen occ dom cod ren) = PRen occ dom (cod + 1) ren
 --   Optionally returns a pruning of nonlinear spine entries, if there's any.
 invert :: Lvl -> Spine -> IO (PartialRenaming, Maybe Pruning)
 invert gamma sp = do
-  let go :: Spine -> IO (Lvl, IS.IntSet, IM.IntMap Lvl, IS.IntSet, Spine)
-      go []                                        = pure (0, mempty, mempty, mempty, [])
-      go (sp :> (force -> ft@(VVar (Lvl x)), i)) = do 
-        (dom, domvars, ren, nlvars, fsp) <- go sp
-        case IS.member x domvars of
-          True  -> pure (dom + 1, domvars,             IM.delete x ren,     IS.insert x nlvars, fsp :> (ft, i))
-          False -> pure (dom + 1, IS.insert x domvars, IM.insert x dom ren, nlvars,             fsp :> (ft, i))
-      go _                                         = throwIO UnifyError
+  let go :: Spine -> IO (Lvl, IM.IntMap Lvl, IS.IntSet, [(Lvl, Icit)])
+      go []                                 = pure (0, mempty, mempty, [])
+      go (sp :> (force -> VVar (Lvl x), i)) = do 
+        (dom, ren, nlvars, fsp) <- go sp
+        case IM.member x ren || IS.member x nlvars of
+          True  -> pure (dom + 1, IM.delete x ren,     IS.insert x nlvars, fsp :> (Lvl x, i))
+          False -> pure (dom + 1, IM.insert x dom ren, nlvars,             fsp :> (Lvl x, i))
+      go _                                  = throwIO UnifyError
 
-  (dom, domvars, ren, nlvars, fsp) <- go sp
+  (dom, ren, nlvars, fsp) <- go sp
 
-  let mask :: Spine -> Pruning 
-      mask []                         = []
-      mask (fsp :> (VVar (Lvl x), i)) 
-        | IS.member x nlvars          = Nothing : mask fsp
-        | otherwise                   = Just i : mask fsp
-      mask _                          = impossible
+  let mask :: [(Lvl, Icit)] -> Pruning 
+      mask []                  = []
+      mask (fsp :> (Lvl x, i)) 
+        | IS.member x nlvars   = Nothing : mask fsp
+        | otherwise            = Just i  : mask fsp
 
   pure (PRen Nothing dom gamma ren, mask fsp <$ guard (not $ IS.null nlvars))
 

--- a/06-first-class-poly/Elaboration.hs
+++ b/06-first-class-poly/Elaboration.hs
@@ -105,20 +105,25 @@ skip (PRen occ dom cod ren) = PRen occ dom (cod + 1) ren
 --   Optionally returns a pruning of nonlinear spine entries, if there's any.
 invert :: Lvl -> Spine -> IO (PartialRenaming, Maybe Pruning)
 invert gamma sp = do
+  let go :: Spine -> IO (Lvl, IS.IntSet, IM.IntMap Lvl, IS.IntSet, Spine)
+      go []                                        = pure (0, mempty, mempty, mempty, [])
+      go (sp :> (force -> ft@(VVar (Lvl x)), i)) = do 
+        (dom, domvars, ren, nlvars, fsp) <- go sp
+        case IS.member x domvars of
+          True  -> pure (dom + 1, domvars,             IM.delete x ren,     IS.insert x nlvars, fsp :> (ft, i))
+          False -> pure (dom + 1, IS.insert x domvars, IM.insert x dom ren, nlvars,             fsp :> (ft, i))
+      go _                                         = throwIO UnifyException
 
-  let go :: Spine -> IO (Lvl, IS.IntSet, IM.IntMap Lvl, Pruning, Bool)
-      go []             = pure (0, mempty, mempty, [], True)
-      go (sp :> (t, i)) = do
-        (dom, domvars, ren, pr, isLinear) <- go sp
-        case force t of
-          VVar (Lvl x) -> case IS.member x domvars of
-            True  -> pure (dom + 1, domvars,             IM.delete x ren,     Nothing : pr, False   )
-            False -> pure (dom + 1, IS.insert x domvars, IM.insert x dom ren, Just i  : pr, isLinear)
-          _ -> throwIO UnifyException
+  (dom, domvars, ren, nlvars, fsp) <- go sp
 
-  (dom, domvars, ren, pr, isLinear) <- go sp
-  pure (PRen Nothing dom gamma ren, pr <$ guard (not isLinear))
+  let mask :: Spine -> Pruning 
+      mask []                         = []
+      mask (fsp :> (VVar (Lvl x), i)) 
+        | IS.member x nlvars          = Nothing : mask fsp
+        | otherwise                   = Just i : mask fsp
+      mask _                          = impossible
 
+  pure (PRen Nothing dom gamma ren, mask fsp <$ guard (not $ IS.null nlvars))
 
 -- | Remove some arguments from a closed iterated Pi type.
 pruneTy :: Dbg => RevPruning -> VTy -> IO Ty


### PR DESCRIPTION
As discussed in issue #32, the computation of the pruning mask seems to be not correct. As an effect, the first occurrence of a non-linear variable was neither renamed nor pruned.

This PR closes this issue by proceeding as proposed by @AndrasKovacs: We first compute the partial renaming, returning a set of non-linear variables and the forced spine. A second function `mask` then creates the pruning mask where *all* occurrences of a non-linear variable are pruned.

The changes affect package `05-pruning` and `06-first-class-poly`, where only the function `invert` has been rewritten to:

```haskell
invert :: Lvl -> Spine -> IO (PartialRenaming, Maybe Pruning)
invert gamma sp = do
  let go :: Spine -> IO (Lvl, IS.IntSet, IM.IntMap Lvl, IS.IntSet, Spine)
      go []                                        = pure (0, mempty, mempty, mempty, [])
      go (sp :> (force -> ft@(VVar (Lvl x)), i)) = do 
        (dom, domvars, ren, nlvars, fsp) <- go sp
        case IS.member x domvars of
          True  -> pure (dom + 1, domvars,             IM.delete x ren,     IS.insert x nlvars, fsp :> (ft, i))
          False -> pure (dom + 1, IS.insert x domvars, IM.insert x dom ren, nlvars,             fsp :> (ft, i))
      go _                                         = throwIO UnifyError

  (dom, domvars, ren, nlvars, fsp) <- go sp

  let mask :: Spine -> Pruning 
      mask []                         = []
      mask (fsp :> (VVar (Lvl x), i)) 
        | IS.member x nlvars          = Nothing : mask fsp
        | otherwise                   = Just i : mask fsp
      mask _                          = impossible

  pure (PRen Nothing dom gamma ren, mask fsp <$ guard (not $ IS.null nlvars))
```