### PR TITLE
Reuse `quote` for value renaming

### DIFF
--- a/04-implicit-args/Cxt.hs
+++ b/04-implicit-args/Cxt.hs
@@ -1,6 +1,8 @@
 
 module Cxt where
 
+import Data.Functor.Identity
+
 import Common
 import Evaluation
 import Pretty
@@ -27,7 +29,7 @@ cxtNames = fmap (\(x, _, _) -> x) . types
 
 showVal :: Cxt -> Val -> String
 showVal cxt v =
-  prettyTm 0 (cxtNames cxt) (quote (lvl cxt) v) []
+  prettyTm 0 (cxtNames cxt) (runIdentity $ quote (lvl cxt) v) []
 
 showTm :: Cxt -> Tm -> String
 showTm cxt t = prettyTm 0 (cxtNames cxt) t []
@@ -55,4 +57,4 @@ define (Cxt env l types bds pos) x ~t ~a  =
 
 -- | closeVal : (Γ : Con) → Val (Γ, x : A) B → Closure Γ A B
 closeVal :: Cxt -> Val -> Closure
-closeVal cxt t = Closure (env cxt) (quote (lvl cxt + 1) t)
+closeVal cxt t = Closure (env cxt) (runIdentity $ quote (lvl cxt + 1) t)

--- a/04-implicit-args/Elaboration.hs
+++ b/04-implicit-args/Elaboration.hs
@@ -17,6 +17,7 @@ import Unification
 import Value
 
 import qualified Presyntax as P
+import Data.Functor.Identity (Identity(runIdentity))
 
 
 -- Elaboration
@@ -33,7 +34,7 @@ unifyCatch :: Cxt -> Val -> Val -> IO ()
 unifyCatch cxt t t' =
   unify (lvl cxt) t t'
   `catch` \UnifyError ->
-    throwIO $ Error cxt $ CantUnify (quote (lvl cxt) t) (quote (lvl cxt) t')
+    throwIO $ Error cxt $ CantUnify (runIdentity $ quote (lvl cxt) t) (runIdentity $ quote (lvl cxt) t')
 
 -- | Insert fresh implicit applications.
 insert' :: Cxt -> IO (Tm, VTy) -> IO (Tm, VTy)

--- a/04-implicit-args/Main.hs
+++ b/04-implicit-args/Main.hs
@@ -15,6 +15,7 @@ import Pretty
 import Elaboration
 
 import qualified Presyntax as P
+import Data.Functor.Identity (Identity(runIdentity))
 
 --------------------------------------------------------------------------------
 
@@ -40,10 +41,10 @@ mainWith getOpt getRaw = do
       (t, a) <- elab
       putStrLn $ showTm0 $ nf [] t
       putStrLn "  :"
-      putStrLn $ showTm0 $ quote 0 a
+      putStrLn $ showTm0 $ runIdentity $ quote (Lvl 0) a
     ["type"] -> do
       (t, a) <- elab
-      putStrLn $ showTm0 $ quote 0 a
+      putStrLn $ showTm0 $ runIdentity $ quote (Lvl 0) a
     ["elab"] -> do
       (t, a) <- elab
       displayMetas

--- a/04-implicit-args/Pretty.hs
+++ b/04-implicit-args/Pretty.hs
@@ -3,6 +3,7 @@ module Pretty (prettyTm, showTm0, displayMetas) where
 
 import Control.Monad
 import Data.IORef
+import Data.Functor.Identity
 import Text.Printf
 
 import qualified Data.IntMap.Strict as IM
@@ -85,5 +86,5 @@ displayMetas = do
   ms <- readIORef mcxt
   forM_ (IM.toList ms) $ \(m, e) -> case e of
     Unsolved -> printf "let ?%s = ?;\n" (show m)
-    Solved v -> printf "let ?%s = %s;\n" (show m) (showTm0 $ quote 0 v)
+    Solved v -> printf "let ?%s = %s;\n" (show m) (showTm0 $ runIdentity $ quote (Lvl 0) v)
   putStrLn ""


### PR DESCRIPTION
This PR eliminates the need for `rename` during pattern unification by reusing a generalized version of `quote`.

The reasoning behind this change is that `rename` duplicates all the cases of `quote` except for processing spine heads, thus increasing maintenance burden and risk of bugs. In `04-implicit-args`, this change does not reduce code size significantly, however, if the minimal implementations in this repository are to be extensible to something more complex than pure lambda calculus, this reuse of `quote` would make it much easier.

If this change is welcomed, I'd be willing to adapt it to other unification-based implementations: `03-holes`, `03-holes-unit-eta`, `05-pruning`, and possibly `06-first-class-poly`. If not, at least people should be able to see in this PR how to achieve reuse of quotation.

I've tested the new implementation on `04-implicit-args/example.txt` -- it seems to work fine.
