### PR TITLE
fix: typos

### DIFF
--- a/01-eval-closures-debruijn/Main.hs
+++ b/01-eval-closures-debruijn/Main.hs
@@ -66,7 +66,7 @@ eval env = \case
 lvl2Ix :: Lvl -> Lvl -> Ix
 lvl2Ix (Lvl l) (Lvl x) = Ix (l - x - 1)
 
-quote :: Lvl -> Val -> Tm              -- normalization-by-evaulation
+quote :: Lvl -> Val -> Tm              -- normalization-by-evaluation
 quote l = \case
   VVar x   -> Var (lvl2Ix l x)
   VApp t u -> App (quote l t) (quote l u)

--- a/02-typecheck-HOAS-names/Main.hs
+++ b/02-typecheck-HOAS-names/Main.hs
@@ -194,7 +194,7 @@ infer env cxt = \case
         "Expected a function type, instead inferred:\n\n  "
         ++ quoteShow env tty
 
-  Lam{} -> report "Can't infer type for lambda expresion"
+  Lam{} -> report "Can't infer type for lambda expression"
 
   Pi x a b -> do
     check env cxt a VU

--- a/03-holes/Main.hs
+++ b/03-holes/Main.hs
@@ -280,7 +280,7 @@ type Env     = [Val]
 {- `Spine` is a snoc list of variable. 
 
    all `Val` in snoc list should be `VVal`,
-   otherwise would throw UnifyError in `invert` fucntion. -}
+   otherwise would throw UnifyError in `invert` function. -}
 type Spine   = [Val]
 
 data Closure = Closure Env Tm
@@ -375,7 +375,7 @@ do no such update here. It is possible here to use destructive forcing update, b
 we'd have to use explicit mutable references. And unfortunately those references stay with
 us forever as indirections, unlike thunks which are eventually removed by GHC garbage collection.
 
-Ideally, we'd have a runtime system which natively supports simulatenous forcing of thunks
+Ideally, we'd have a runtime system which natively supports simultaneous forcing of thunks
 and flexible values, with value update as well. That's a lot of work to implement, so we
 stick with a less efficient shallow embedding in Haskell.
 -}

--- a/06-first-class-poly/Metacontext.hs
+++ b/06-first-class-poly/Metacontext.hs
@@ -21,7 +21,7 @@ import Syntax
 
 data CheckEntry
   -- ^ In (Unchecked Γ t A m), we postpone checking t with A in Γ and create m
-  --   as a fresh meta, which is a "placedholder" for the eventual checking
+  --   as a fresh meta, which is a "placeholder" for the eventual checking
   --   result. After we actually perform the checking, we have to unify the
   --   result with the placeholder.
   = Unchecked Cxt P.Tm VTy MetaVar

--- a/GluedEval.hs
+++ b/GluedEval.hs
@@ -28,7 +28,7 @@ lazy non-deterministic choice in the semantic domain. We extend values with
     ... | VTop Name Spine ~Val
 
 where Name and Spine constitute a neutral expression whose head is a top-level
-definition name, and ~Val is the lazy result of evaluating the same netural
+definition name, and ~Val is the lazy result of evaluating the same neutral
 expression, but with the top definition unfolded.
 
 Hence, when we hit VTop during processing Val-s, we can choose between

--- a/experiments/mltt-lock/Main.hs
+++ b/experiments/mltt-lock/Main.hs
@@ -324,7 +324,7 @@ infer = \case
         ++ quoteShow tty
 
   Lam{} ->
-    report "Can't infer type for lambda expresion"
+    report "Can't infer type for lambda expression"
 
   Box t -> lock do
     check t VU

--- a/experiments/runtime-codegen/Main.hs
+++ b/experiments/runtime-codegen/Main.hs
@@ -422,7 +422,7 @@ infer = \case
         ++ quoteShow tty
 
   RLam{} ->
-    report "Can't infer type for lambda expresion"
+    report "Can't infer type for lambda expression"
 
   RBox t -> do
     t <- check t VU

--- a/experiments/sigma-unification/demo.txt
+++ b/experiments/sigma-unification/demo.txt
@@ -200,7 +200,7 @@ General idea:
    Γ, f, x ⊢ f x ↦ a f x
 
   Actual rules:  Γᵤ|Γₛ|Γₚ ⊢ t ↦ rhs
-     Γᵤ : "unsolvable" (irrelvant to to problem)
+     Γᵤ : "unsolvable" (irrelevant to to problem)
      Γₛ : "solvable"   (variables to be mapped)
      Γₚ : "parameter"  (variables which solvable vars can be applied to)
 

--- a/experiments/sigma-unification/notes2.txt
+++ b/experiments/sigma-unification/notes2.txt
@@ -156,7 +156,7 @@ Examples:
     - lots of new metas
     - compute all the new types of new metas
     - transport everything along isos between old/new meta types
-    - not obvious how to minmize amount of work done
+    - not obvious how to minimize amount of work done
     - we have to do eta-reduction (not efficient in the presence of Σ types)
         (t.1, t.2) --> t   (requires conversion checking)
 	(λ x. f x) --> f   (this can be done OK)


### PR DESCRIPTION
- #44 

run `typos -w` will automatically fix typos.

`typos` is very cool Rust CLI tools.

https://github.com/crate-ci/typos