### PR TITLE
Fix a typo in 03-holes

### DIFF
--- a/03-holes/Main.hs
+++ b/03-holes/Main.hs
@@ -502,7 +502,7 @@ As I mentioned before, this spine⁻¹ is only a *partial* inverse, so performin
 can fail.
 -}
 
---  invert : (Γ : Cxt) → (spine : Sub Δ Γ) → PRen Γ Δ
+--  invert : (Γ : Cxt) → (spine : Sub Γ Δ) → PRen Δ Γ
 invert :: Lvl -> Spine -> IO PartialRenaming
 invert gamma sp = do
 


### PR DESCRIPTION
The substitution should be $\texttt{spine} : \Gamma \to \Delta$, since $\texttt{spine}$ represents the free variables of $A$ (ie the variables in context $\Delta$) in terms of variables of $\Gamma$. Also this makes $\Gamma \vdash \texttt{rhs} : A[\texttt{spine}]$ well-formed, which it isn't if $\texttt{spine} : \Delta \to \Gamma$