### PR TITLE
Fix the context order of Sub/PRen in invert comment

### DIFF
--- a/04-implicit-args/Unification.hs
+++ b/04-implicit-args/Unification.hs
@@ -28,7 +28,7 @@ lift :: PartialRenaming -> PartialRenaming
 lift (PRen dom cod ren) =
   PRen (dom + 1) (cod + 1) (IM.insert (unLvl cod) dom ren)
 
--- | @invert : (Γ : Cxt) → (spine : Sub Δ Γ) → PRen Γ Δ@
+-- | @invert : (Γ : Cxt) → (spine : Sub Γ Δ) → PRen Δ Γ@
 invert :: Lvl -> Spine -> IO PartialRenaming
 invert gamma sp = do
 

--- a/05-pruning/Unification.hs
+++ b/05-pruning/Unification.hs
@@ -31,7 +31,7 @@ lift (PRen occ dom cod ren) = PRen occ (dom + 1) (cod + 1) (IM.insert (unLvl cod
 skip :: PartialRenaming -> PartialRenaming
 skip (PRen occ dom cod ren) = PRen occ dom (cod + 1) ren
 
--- | invert : (Γ : Cxt) → (spine : Sub Δ Γ) → PRen Γ Δ
+-- | invert : (Γ : Cxt) → (spine : Sub Γ Δ) → PRen Δ Γ
 --   Optionally returns a pruning of nonlinear spine entries, if there's any.
 invert :: Lvl -> Spine -> IO (PartialRenaming, Maybe Pruning)
 invert gamma sp = do

--- a/06-first-class-poly/Elaboration.hs
+++ b/06-first-class-poly/Elaboration.hs
@@ -101,7 +101,7 @@ lift (PRen occ dom cod ren) = PRen occ (dom + 1) (cod + 1) (IM.insert (unLvl cod
 skip :: PartialRenaming -> PartialRenaming
 skip (PRen occ dom cod ren) = PRen occ dom (cod + 1) ren
 
--- | @invert : (Γ : Cxt) → (spine : Sub Δ Γ) → PRen Γ Δ@
+-- | @invert : (Γ : Cxt) → (spine : Sub Γ Δ) → PRen Δ Γ@
 --   Optionally returns a pruning of nonlinear spine entries, if there's any.
 invert :: Lvl -> Spine -> IO (PartialRenaming, Maybe Pruning)
 invert gamma sp = do

--- a/experiments/super-mega-poly/Unification.hs
+++ b/experiments/super-mega-poly/Unification.hs
@@ -31,7 +31,7 @@ lift (PRen occ dom cod ren) = PRen occ (dom + 1) (cod + 1) (IM.insert (unLvl cod
 skip :: PartialRenaming -> PartialRenaming
 skip (PRen occ dom cod ren) = PRen occ dom (cod + 1) ren
 
--- | invert : (Γ : Cxt) → (spine : Sub Δ Γ) → PRen Γ Δ
+-- | invert : (Γ : Cxt) → (spine : Sub Γ Δ) → PRen Δ Γ
 --   Optionally returns a pruning of nonlinear spine entries, is there's any.
 invert :: Lvl -> Spine -> IO (PartialRenaming, Maybe Pruning)
 invert gamma sp = do


### PR DESCRIPTION
Invert accepts a level `(Γ : Ctx)` that comes from traversing into binders during unification. Thus a meta spine should be `Sub Γ Δ`.